### PR TITLE
Add renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+        "config:base"
+    ],
+    "rangeStrategy": "auto",
+    "semanticCommits": "enabled",
+    "branchConcurrentLimit": 10,
+    "reviewersFromCodeOwners": true
+}


### PR DESCRIPTION
Add package renovate config. This configuration makes sure that it pins only devDependencies. More info https://docs.renovatebot.com/configuration-options/#rangestrategy

As we use renovate across repos to manage dependencies, I thought it would be a good idea to include it in the template. 
