### PR TITLE
ci: remove Windows testing by default

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.0, 8.1]
         laravel: [8.*]
         stability: [prefer-lowest, prefer-stable]


### PR DESCRIPTION
We don't use Windows, and half the time it fails due to permissions errors. 🤷🏻